### PR TITLE
Test on current lts and stable nodejs versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "0.12.10"
-  - "4"
-  - "6"
-  - "8"
-  - "10"
+  - "lts/argon"
+  - "lts/boron"
+  - "lts/carbon"
+  - "lts/dubnium"
+  - "stable"


### PR DESCRIPTION
Dropped "0.12.10" and added codename identifiers for lts and stable according to nvm and the official release schedule.

https://github.com/nodejs/Release

@simenkid as `lts/argon` and `lts/boron` have reached end of life, are there any reasons against dropping support for 4.x and 6.x?