### PR TITLE
Drop support for node 4.x and 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "lts/argon"
-  - "lts/boron"
-  - "lts/carbon"
-  - "lts/dubnium"
-  - "stable"
+  - "8"
+  - "10"
+  - "11"
+  - "12"


### PR DESCRIPTION
- Drop support for 4.x (argon)
- Drop support for 6.x (boron)
- Add support for 12.x (had to switch from codenames to versions, as nvm points stable to 11.x currently and codename for 12.x LTS not announced yet)

