### PR TITLE
Move smartobject to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "debug": "^4.1.1",
     "lwmqn-util": "^0.5.1",
     "mqtt": "^3.0.0",
-    "network": "^0.4.1",
-    "smartobject": "^1.4.0"
+    "network": "^0.4.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^6.1.4",
     "sinon": "^7.3.2",
     "sinon-chai": "^3.3.0",
+    "smartobject": "^1.4.4",
     "snazzy": "^8.0.0",
     "standard": "^12.0.1"
   }


### PR DESCRIPTION
It seems that smartobject is needed only for `mqnode.test.js`